### PR TITLE
fix: automatically add `name` to `dang` response

### DIFF
--- a/pkg/sender/sender.go
+++ b/pkg/sender/sender.go
@@ -151,6 +151,10 @@ func bindConnection(server *socketio.Server) {
 			logger.Printf("[%s-%s | EVT | ping | need to set timestamp, use defauts\n", state.userID, state.roomID)
 			signal["timestamp"] = time.Now().UnixMilli()
 		}
+		// add "name" from state
+		if signal["name"] == nil {
+			signal["name"] = state.userID
+		}
 		logger.Printf("[%s-%s] | EVT | ping | %v - (%T)\n", state.userID, state.roomID, signal, signal)
 		// broadcast to all receivers
 		buf, _ := json.Marshal(signal)


### PR DESCRIPTION
Since the `dang` event is broadcasting to all users, now we automatically add `name` to `dang` event in `vhq-backend`, then the `vhq-frontend` should filter the `dang` response and ignore the data if the `name` doesn't match the current user.